### PR TITLE
proxy `/.well-known/acme-challenge/` to the certbot server (#38)

### DIFF
--- a/data/nginx-terminate/nginx.conf
+++ b/data/nginx-terminate/nginx.conf
@@ -10,7 +10,8 @@ http {
         listen 80;
 
         location /.well-known/acme-challenge/ {
-            alias /var/www/certbot/;
+            # init-certificate.sh uses --standalone, so we must proxy renewals to the certbot server
+            proxy_pass http://certbot:80;
         }
 
         location / {


### PR DESCRIPTION
Cherry-pick from upstream.